### PR TITLE
Update documentation.yaml to use right path

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Run builder
         run: python3 .github/pages.py
         env:
-          KSC_EXECUTABLE: "${{ vars.GITHUB_WORKSPACE }}/vitineth_kaitai/jvm/target/universal/stage/bin/kaitai-struct-compiler"
+          KSC_EXECUTABLE: "vitineth_kaitai/jvm/target/universal/stage/bin/kaitai-struct-compiler"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2


### PR DESCRIPTION
This now assumes that we are in the right directory for this rather than trying to make it explicit. If this doesn't work I'll need to look into it more deeply