### PR TITLE
Update documentation.yaml to enable deploy on merge

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -5,7 +5,7 @@ name: Deploy generated documentation content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This will run deployments on merge, turns out that variable only works in templates, not in actual workflows