### PR TITLE
Use main branch of compiler instead of patch

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'Vitineth/kaitai_struct_compiler'
-          ref: 'vitineth/patches'
+          ref: 'main'
           path: 'vitineth_kaitai'
 
       - name: Compile Kaitai


### PR DESCRIPTION
The compiler project is now using the main branch instead of the branch so this needs to be updated to continue getting patches